### PR TITLE
(NETDEV-20) Change snmp receiver namevar to host, port, username

### DIFF
--- a/spec/support/shared_examples_for_types.rb
+++ b/spec/support/shared_examples_for_types.rb
@@ -369,6 +369,21 @@ RSpec.shared_examples 'string value' do
   end
 end
 
+RSpec.shared_examples 'string parameter value' do
+  ['Engineering'].each do |val|
+    it "accepts #{val.inspect}" do
+      type[attribute] = val
+    end
+  end
+
+  [0, [1], { two: :three }].each do |val|
+    it "rejects #{val.inspect}" do
+      expect { type[attribute] = val }
+        .to raise_error Puppet::ResourceError, /is invalid, must be a String/
+    end
+  end
+end
+
 RSpec.shared_examples 'rejects values' do |values|
   [*values].each do |val|
     it "rejects #{val.inspect} with a Puppet::Error" do
@@ -408,5 +423,13 @@ RSpec.shared_examples 'it has a string property' do |attribute|
     let(:attribute) { attribute }
     include_examples '#doc Documentation'
     include_examples 'string value'
+  end
+end
+
+RSpec.shared_examples 'it has a string parameter' do |attribute|
+  describe "#{attribute}" do
+    let(:attribute) { attribute }
+    include_examples '#doc Documentation'
+    include_examples 'string parameter value'
   end
 end

--- a/spec/unit/puppet/type/snmp_notification_receiver_spec.rb
+++ b/spec/unit/puppet/type/snmp_notification_receiver_spec.rb
@@ -10,9 +10,9 @@ describe Puppet::Type.type(:snmp_notification_receiver) do
 
   it_behaves_like 'an ensurable type'
   it_behaves_like 'name is the namevar'
+  it_behaves_like 'it has a string parameter', :username
   it_behaves_like 'it has a string property', :vrf
   it_behaves_like 'it has a string property', :source_interface
-  it_behaves_like 'it has a string property', :username
 
   describe 'type' do
     let(:attribute) { :type }
@@ -40,11 +40,5 @@ describe Puppet::Type.type(:snmp_notification_receiver) do
     include_examples '#doc Documentation'
     include_examples 'numeric parameter', min: 0, max: 65_536
     include_examples 'rejects values', %w(foo bar baz)
-  end
-
-  describe 'community' do
-    let(:attribute) { :community }
-    include_examples '#doc Documentation'
-    include_examples 'string value'
   end
 end


### PR DESCRIPTION
Without this patch the snmp_notification_receiver specifies the name
parameter as the sole namevar.  This is a problem because there can be
multiple resources with the same hostname or IP address.  This patch
addresses the problem by changing the type to build a composite namevar
that joins hostname, port, and username with a colon to form the
resource identifier.  This looks like:

```
$ puppet resource snmp_notification_receiver
snmp_notification_receiver { '127.0.0.1:public:162':
  ensure   => 'present',
  security => 'noauth',
  type     => 'traps',
  version  => 'v3',
}
snmp_notification_receiver { '127.0.0.2:public:162':
  ensure   => 'present',
  security => 'noauth',
  type     => 'traps',
  version  => 'v3',
}
```

NOTE: Namevar components cannot be properties because of the
[key_attribute_parameters class method](https://github.com/puppetlabs/puppet/blob/3.7.1/lib/puppet/type.rb#L355-L361) on the
type.

This patch also removes the community attribute.  The username property
now represents both the snmp username or the snmp community depending on
the snmp version of the notification receiver.
