### PR TITLE
(NETDEV-22) Change snmp_user to composite namevar on name, version

### DIFF
--- a/lib/puppet/type/snmp_user.rb
+++ b/lib/puppet/type/snmp_user.rb
@@ -15,6 +15,12 @@ Puppet::Type.newtype(:snmp_user) do
     end
   end
 
+  newparam(:version, namevar: true) do
+    desc 'SNMP version [v1|v2|v3]'
+
+    newvalues(:v1, :v2, :v3)
+  end
+
   newproperty(:roles, array_matching: :all) do
     desc 'A list of roles associated with this SNMP user'
 
@@ -73,5 +79,15 @@ Puppet::Type.newtype(:snmp_user) do
       else fail "value #{value.inspect} is invalid, must be a String."
       end
     end
+  end
+
+  def self.title_patterns
+    identity = nil # optimization in Puppet core
+    name = [ :name, identity ]
+    version  = [ :version, lambda { |x| x.intern } ]
+    [
+      [ /^([^:]*)$/,                 [ name ] ],
+      [ /^([^:]*):([^:]*)$/,         [ name, version ] ],
+    ]
   end
 end


### PR DESCRIPTION
Without this patch the snmp_user type identifies resources by name only. This
is a problem because the same user name can exist multiple times on the target
device provided each user is for a different SNMP version. This patch addresses
the problem by changing the resource model to use version as a namevar
component.
