### PR TITLE
(NETDEV-23) Add network_dns type

### DIFF
--- a/lib/puppet/type/network_dns.rb
+++ b/lib/puppet/type/network_dns.rb
@@ -1,0 +1,52 @@
+# encoding: utf-8
+
+Puppet::Type.newtype(:network_dns) do
+  @doc = 'Configure DNS settings for network devices'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'Resource name, not used to configure the device'
+
+    validate do |value|
+      if value.is_a? String then super(value)
+      else fail "value #{value.inspect} is invalid, must be a String."
+      end
+    end
+  end
+
+  newproperty(:domain) do
+    desc 'The default domain name to append to the device hostname'
+
+    validate do |value|
+      if value.is_a? String then super(value)
+      else fail "value #{value.inspect} is invalid, must be a String."
+      end
+    end
+  end
+
+  newproperty(:search, array_matching: :all) do
+    desc 'Array of DNS suffixes to search for FQDN entries'
+
+    validate do |val|
+      fail "value #{val.inspect} must be a string" unless val.is_a? String
+    end
+
+    def insync?(is)
+      is.sort == @should.sort.map(&:to_s)
+    end
+  end
+
+  newproperty(:servers, array_matching: :all) do
+    desc 'Array of DNS servers to use for name resolution'
+
+    validate do |val|
+      fail "value #{val.inspect} must be a string" unless val.is_a? String
+    end
+
+    def insync?(is)
+      is.sort == @should.sort.map(&:to_s)
+    end
+  end
+
+end

--- a/spec/unit/puppet/type/network_dns_spec.rb
+++ b/spec/unit/puppet/type/network_dns_spec.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Puppet::Type.type(:network_dns) do
+  let(:catalog) { Puppet::Resource::Catalog.new }
+  let(:type) { described_class.new(name: 'emanon', catalog: catalog) }
+
+  subject { described_class.attrclass(attribute) }
+
+  it_behaves_like 'name is the namevar'
+  it_behaves_like 'it has a string property', :domain
+
+  [:search, :servers].each do |param|
+    describe param.to_s do
+      let(:attribute) { param }
+      include_examples 'array of strings value'
+    end
+  end
+
+end


### PR DESCRIPTION
This adds support for an aggregate network DNS type that combines NETDEV-5 NETDEV-6 NETDEV-7 types into a single aggregate type.  This aggregate type should obsolete NETDEV-5 NETDEV-6 NETDEV-7 once merged.
