### PR TITLE
modifies network_dns to remove ensurable

### DIFF
--- a/lib/puppet/type/network_dns.rb
+++ b/lib/puppet/type/network_dns.rb
@@ -3,8 +3,6 @@
 Puppet::Type.newtype(:network_dns) do
   @doc = 'Configure DNS settings for network devices'
 
-  ensurable
-
   newparam(:name, namevar: true) do
     desc 'Name, generally "settings", not used to manage the resource'
 


### PR DESCRIPTION
This proposed update removes the ensureable setting from network_dns since it
does not make sense.  The network_dns type configures global settings for
dns domain, search and servers. There are no unique instances of type
network_dns therefore it does not make sense for the type to be ensurable.

For specifying ensurable entries in the search and servers arrays the
name_server and search_domain types should be used instead.