### PR TITLE
(NETDEV-29) Enhance ntp_config + ntp_server add ntp_auth_key

### DIFF
--- a/lib/puppet/type/ntp_auth_key.rb
+++ b/lib/puppet/type/ntp_auth_key.rb
@@ -1,0 +1,41 @@
+# encoding: utf-8
+
+require_relative '../../puppet_x/puppetlabs/netdev_stdlib/property/port_range'
+
+Puppet::Type.newtype(:ntp_auth_key) do
+  @doc = 'NTP Authentication keys'
+
+  apply_to_all
+  ensurable
+
+  newparam(:name, namevar: true, parent: PuppetX::PuppetLabs::NetdevStdlib::Property::PortRange) do
+    desc 'Authentication key ID'
+
+    # Make sure we have a string, casting to int first also strips whitespace
+    munge do |value|
+      Integer(value).to_s
+    end
+  end
+
+  newproperty(:algorithm) do
+    desc 'Hash algorithm [md5|sha1|sha256]'
+
+    newvalues(:md5, :sha1, :sha256)
+  end
+
+  newproperty(:mode) do
+    desc 'Password mode [0 (plain) | 7 (encrypted)]'
+
+    munge { |v| Integer(v) }
+  end
+
+  newproperty(:password) do
+    desc 'Password text'
+
+    validate do |value|
+      fail "value #{value.inspect} is invalid, must be a String." unless
+      value.is_a? String
+      super(value)
+    end
+  end
+end

--- a/lib/puppet/type/ntp_config.rb
+++ b/lib/puppet/type/ntp_config.rb
@@ -15,6 +15,11 @@ Puppet::Type.newtype(:ntp_config) do
     end
   end
 
+  newproperty(:authenticate) do
+    desc 'NTP authentication enabled [true|false]'
+    newvalues(:true, :false)
+  end
+
   newproperty(:source_interface) do
     desc 'The source interface for the NTP system'
 
@@ -22,6 +27,28 @@ Puppet::Type.newtype(:ntp_config) do
       if value.is_a? String then super(value)
       else fail "value #{value.inspect} is invalid, must be a String."
       end
+    end
+  end
+
+  newproperty(:trusted_key, array_matching: :all) do
+    desc 'Array of global trusted-keys.  Contents can be a String or Integers'
+
+    validate do |value|
+      if (value.is_a? String) || (value.is_a? Integer) then super(value)
+      else fail "value #{value.inspect} is invalid, must be a String or Integer."
+      end
+    end
+
+    def insync?(is)
+      is.map(&:to_s).sort == @should.map(&:to_s).sort
+    end
+
+    def should_to_s(new_value=@should)
+      self.class.format_value_for_display(new_value)
+    end
+
+    def is_to_s(current_value=@is)
+      self.class.format_value_for_display(current_value)
     end
   end
 end

--- a/lib/puppet/type/ntp_server.rb
+++ b/lib/puppet/type/ntp_server.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require_relative '../../puppet_x/puppetlabs/netdev_stdlib/property/port_range'
+
 Puppet::Type.newtype(:ntp_server) do
   @doc = 'Specify an NTP server'
 
@@ -16,8 +18,44 @@ Puppet::Type.newtype(:ntp_server) do
     end
   end
 
+  newproperty(:key, parent: PuppetX::PuppetLabs::NetdevStdlib::Property::PortRange) do
+    desc 'Authentication key ID'
+
+    munge { |v| Integer(v) }
+  end
+
+  newproperty(:maxpoll) do
+    desc 'The maximul poll interval'
+    munge { |v| Integer(v) }
+  end
+
+  newproperty(:minpoll) do
+    desc 'The minimum poll interval'
+    munge { |v| Integer(v) }
+  end
+
   newproperty(:prefer) do
     desc 'Prefer this NTP server [true|false]'
     newvalues(:true, :false)
+  end
+
+  newproperty(:source_interface) do
+    desc 'The source interface used to reach the NTP server'
+
+    validate do |value|
+      if value.is_a? String then super(value)
+      else fail "value #{value.inspect} is invalid, must be a String."
+      end
+    end
+  end
+
+  newproperty(:vrf) do
+    desc 'The VRF instance this server is bound to.'
+
+    validate do |value|
+      if value.is_a? String then super(value)
+      else fail "value #{value.inspect} is invalid, must be a String."
+      end
+    end
   end
 end

--- a/lib/puppet_x/puppetlabs/netdev_stdlib/property/port_range.rb
+++ b/lib/puppet_x/puppetlabs/netdev_stdlib/property/port_range.rb
@@ -1,0 +1,15 @@
+module PuppetX
+  module PuppetLabs
+    module NetdevStdlib
+      module Property
+        class PortRange < Puppet::Property
+          validate do |value|
+            fail "value #{value.inspect} is invalid, must be 1-65535." unless
+            value.to_i.between?(1, 65_535)
+            super(value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/ntp_auth_key_spec.rb
+++ b/spec/unit/puppet/type/ntp_auth_key_spec.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Puppet::Type.type(:ntp_auth_key) do
+  let(:catalog) { Puppet::Resource::Catalog.new }
+  let(:type) { described_class.new(name: 10, catalog: catalog) }
+  subject { described_class.attrclass(attribute) }
+
+  it_behaves_like 'numeric namevar', min: 1, max: 65_535
+  it_behaves_like 'it has a string property', :password
+
+  describe 'algorithm' do
+    let(:attribute) { :algorithm }
+
+    include_examples '#doc Documentation'
+    include_examples 'algorithm property'
+  end
+
+  describe 'mode' do
+    let(:attribute) { :mode }
+    include_examples 'numeric parameter', min: 0, max: 7
+  end
+end

--- a/spec/unit/puppet/type/ntp_config_spec.rb
+++ b/spec/unit/puppet/type/ntp_config_spec.rb
@@ -5,4 +5,6 @@ require 'spec_helper'
 describe Puppet::Type.type(:ntp_config) do
   it_behaves_like 'name is the namevar'
   it_behaves_like 'string', attribute: :source_interface
+  it_behaves_like 'boolean', attribute: :authenticate
+  it_behaves_like 'array of strings or integers property', attribute: :trusted_key
 end

--- a/spec/unit/puppet/type/ntp_server_spec.rb
+++ b/spec/unit/puppet/type/ntp_server_spec.rb
@@ -3,6 +3,27 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:ntp_server) do
+  let(:catalog) { Puppet::Resource::Catalog.new }
+  let(:type) { described_class.new(name: 'emanon', catalog: catalog) }
+  subject { described_class.attrclass(attribute) }
+
   it_behaves_like 'name is the namevar'
   it_behaves_like 'boolean', attribute: :prefer
+  it_behaves_like 'string', attribute: :source_interface
+  it_behaves_like 'string', attribute: :vrf
+
+  describe 'key' do
+    let(:attribute) { :key }
+    include_examples 'numeric parameter', min: 1, max: 65_535
+  end
+
+  describe 'maxpoll' do
+    let(:attribute) { :maxpoll }
+    include_examples 'numeric parameter', min: 0, max: 65_535
+  end
+
+  describe 'minpoll' do
+    let(:attribute) { :minpoll }
+    include_examples 'numeric parameter', min: 0, max: 65_535
+  end
 end


### PR DESCRIPTION
This commit enhances the existing ntp_config and ntp_server types

It provides users the ability to configure NTP authentication keys
and utilize them globally and on a per peer basis.

Additionally this commit adds the ability to use VRF's and source
interfaces.

```
ntp_config
  authenticate
  trusted_key

ntp_server
  key
  maxpoll
  minpoll
  source_interface
  vrf

ntp_auth_key
  algorithm
  password
```