### PR TITLE
(NETDEV-35) Deprecate domain_name, name_server, search_domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ types implemented in this module.
    
 # Reference
 ## Resource types
-* [`domain_name`](#domain_name): Configure the domain name of the device
-* [`name_server`](#name_server): Configure the resolver to use the specified DNS server
 * [`network_dns`](#network_dns): Configure DNS settings for network devices
 * [`network_interface`](#network_interface): Manage physical network interfaces, e.g. Ethernet1
 * [`network_snmp`](#network_snmp): Manage snmp location, contact and enable SNMP on the device
@@ -44,7 +42,6 @@ types implemented in this module.
 * [`radius_global`](#radius_global): Configure global radius settings
 * [`radius_server`](#radius_server): Configure a radius server
 * [`radius_server_group`](#radius_server_group): Configure a radius server group
-* [`search_domain`](#search_domain): Configure the resolver to use the specified search domain
 * [`snmp_community`](#snmp_community): Manage the SNMP community
 * [`snmp_notification`](#snmp_notification): Enable or disable notification groups and events
 * [`snmp_notification_receiver`](#snmp_notification_receiver): Manage an SNMP notification receiver
@@ -56,9 +53,15 @@ types implemented in this module.
 * [`tacacs_server`](#tacacs_server): Configure a tacacs server
 * [`tacacs_server_group`](#tacacs_server_group): Configure a tacacs server group
 
+## Deprecated resource types
+The following types have been replaced by [`network_dns`](#network_dns)
+* [`domain_name`](#domain_name): Default domain name to append to the device hostname
+* [`name_server`](#name_server): Configure the resolver to use the specified DNS server
+* [`search_domain`](#search_domain): DNS suffix to search for FQDN entries
+
 #### domain_name
 
-Configure the domain name of the device.
+Deprecated - Default domain name to append to the device hostname.
 
 
 ##### Properties
@@ -86,7 +89,7 @@ The domain name of the device.
 
 #### name_server
 
-Configure the resolver to use the specified DNS server.
+Deprecated - Configure the resolver to use the specified DNS server.
 
 
 ##### Properties
@@ -728,7 +731,7 @@ The name of the radius server group.
 
 #### search_domain
 
-Configure the resolver to use the specified search domain.
+Deprecated - DNS suffix to search for FQDN entries.
 
 
 ##### Properties

--- a/lib/puppet/type/domain_name.rb
+++ b/lib/puppet/type/domain_name.rb
@@ -1,12 +1,13 @@
 require_relative '../../puppet_x/puppetlabs/netdev_stdlib/check'
 if PuppetX::NetdevStdlib::Check.use_old_netdev_type
   Puppet::Type.newtype(:domain_name) do
-    @doc = 'Configure the domain name of the device'
+    @doc = 'Deprecated - use network_dns instead.  Default domain name to append to the device hostname.'
 
     apply_to_all
     ensurable
 
     newparam(:name, namevar: true) do
+      Puppet.warning('domain_name type is deprecated - use network_dns instead.')
       desc 'The domain name of the device'
 
       validate do |value|
@@ -21,7 +22,7 @@ else
 
   Puppet::ResourceApi.register_type(
     name: 'domain_name',
-    docs: 'Configure the domain name of the device',
+    docs: 'Deprecated - use network_dns instead.  Default domain name to append to the device hostname.',
     features: ['remote_resource'],
     attributes: {
       ensure:       {

--- a/lib/puppet/type/name_server.rb
+++ b/lib/puppet/type/name_server.rb
@@ -1,12 +1,13 @@
 require_relative '../../puppet_x/puppetlabs/netdev_stdlib/check'
 if PuppetX::NetdevStdlib::Check.use_old_netdev_type
   Puppet::Type.newtype(:name_server) do
-    @doc = 'Configure the resolver to use the specified DNS server'
+    @doc = 'Deprecated - use network_dns instead.  Configure the resolver to use the specified DNS server'
 
     apply_to_all
     ensurable
 
     newparam(:name, namevar: true) do
+      Puppet.warning('name_server type is deprecated - use network_dns instead.')
       desc 'The hostname or address of the DNS server'
 
       validate do |value|
@@ -21,7 +22,7 @@ else
 
   Puppet::ResourceApi.register_type(
     name: 'name_server',
-    docs: 'Configure the resolver to use the specified DNS server',
+    docs: 'Deprecated - use network_dns instead.  Configure the resolver to use the specified DNS server',
     features: ['remote_resource'],
     attributes: {
       ensure:       {

--- a/lib/puppet/type/search_domain.rb
+++ b/lib/puppet/type/search_domain.rb
@@ -1,12 +1,13 @@
 require_relative '../../puppet_x/puppetlabs/netdev_stdlib/check'
 if PuppetX::NetdevStdlib::Check.use_old_netdev_type
   Puppet::Type.newtype(:search_domain) do
-    @doc = 'Configure the resolver to use the specified search domain'
+    @doc = 'Deprecated - use network_dns instead.  DNS suffix to search for FQDN entries.'
 
     apply_to_all
     ensurable
 
     newparam(:name, namevar: true) do
+      Puppet.warning('search_domain type is deprecated - use network_dns instead.')
       desc 'The search domain to configure in the resolver'
 
       validate do |value|
@@ -21,7 +22,7 @@ else
 
   Puppet::ResourceApi.register_type(
     name: 'search_domain',
-    docs: 'Configure the resolver to use the specified search domain',
+    docs: 'Deprecated - use network_dns instead.  DNS suffix to search for FQDN entries.',
     features: ['remote_resource'],
     attributes: {
       ensure:       {


### PR DESCRIPTION
The types domain_name, name_server, search_domain should have been deprecated when network_dns was created.
This commit adds a deprecation warning and the types will be removed in the future.
Also resolves confusion documentation around the types - NETDEV-34