### PR TITLE
(FM-6988) Add canonicalize feature to network_interface

### DIFF
--- a/lib/puppet/type/network_interface.rb
+++ b/lib/puppet/type/network_interface.rb
@@ -66,7 +66,7 @@ else
   Puppet::ResourceApi.register_type(
     name: 'network_interface',
     docs: 'Manage physical network interfaces, e.g. Ethernet1',
-    features: ['remote_resource'],
+    features: ['remote_resource', 'canonicalize'],
     attributes: {
       enable: {
         type:    'Optional[Boolean]',


### PR DESCRIPTION
This allows for non-device compatible fields to be removed
from proposed changes from manifest