### PR TITLE
(MODULES-8232) adding ability to unset the params on snmp_notificatio…

### DIFF
--- a/lib/puppet/type/radius_server.rb
+++ b/lib/puppet/type/radius_server.rb
@@ -141,7 +141,7 @@ else
         desc:      'Encryption key (plaintext or in hash form depending on key_format)'
       },
       key_format: {
-        type:      'Optional[Integer]',
+        type:      'Optional[Variant[Integer, Enum["unset"]]]',
         desc:      'Encryption key format [0-7]'
       },
       group: {
@@ -153,7 +153,7 @@ else
         desc:      'Number of minutes to ignore an unresponsive server'
       },
       timeout: {
-        type:      'Optional[Integer]',
+        type:      'Optional[Variant[Integer, Enum["unset"]]]',
         desc:      'Number of seconds before the timeout period ends'
       },
       vrf: {
@@ -165,7 +165,7 @@ else
         desc:      'Source interface to send syslog data from, e.g. "ethernet 2/1"'
       },
       retransmit_count: {
-        type:      'Optional[Integer]',
+        type:      'Optional[Variant[Integer, Enum["unset"]]]',
         desc:      'How many times to retransmit'
       },
       accounting_only: {

--- a/lib/puppet/type/snmp_notification_receiver.rb
+++ b/lib/puppet/type/snmp_notification_receiver.rb
@@ -99,7 +99,7 @@ else
         behaviour:  :namevar
       },
       port: {
-        type:      'Optional[Integer[1, 65535]]',
+        type:      'Optional[Variant[Integer[1, 65535], Enum["unset"], Integer[-1, -1]]]',
         desc:      'SNMP UDP port number'
       },
       username: {

--- a/lib/puppet/type/tacacs_global.rb
+++ b/lib/puppet/type/tacacs_global.rb
@@ -90,7 +90,7 @@ else
         desc:      'Encryption key (plaintext or in hash form depending on key_format)'
       },
       key_format: {
-        type:      'Optional[Integer]',
+        type:      'Optional[Variant[Integer, Enum["unset"]]]',
         desc:      'Encryption key format [0-7]'
       },
       retransmit_count: {
@@ -102,7 +102,7 @@ else
         desc:      'The source interface used for TACACS packets (array of strings for multiple).'
       },
       timeout: {
-        type:      'Optional[Integer]',
+        type:      'Optional[Variant[Integer, Enum["unset"]]]',
         desc:      'Number of seconds before the timeout period ends'
       },
       vrf: {


### PR DESCRIPTION
…n_receiver

`port` is a special case which was a bounded range and to keep feature parity we need flexibility is setting it to `-1` or `'unset'` to unset the value.