### PR TITLE
(FM-8015) adding tag to aid with Forge searches

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,5 +17,8 @@
   "requirements": [
 
   ],
+  "tags": [
+    "network"
+  ],
   "description": "Type definitions for Networking Device (NetDev) Standard Library"
 }


### PR DESCRIPTION
adding the "network" tag to the metadata.json - this will allows searches on the Forge to retrieve all "network" related modules - if tagged appropriately.